### PR TITLE
Disallow use of special characters in container name

### DIFF
--- a/containers/adminer.yml
+++ b/containers/adminer.yml
@@ -16,6 +16,7 @@ config:
         value: adminer
         validators:
             required: true
+            regex: "^[a-z]+$"
       - 
         id: port 
         label: "Port used on the host machine"

--- a/containers/mysql.yml
+++ b/containers/mysql.yml
@@ -16,6 +16,7 @@ config:
         value: mysql
         validators: 
             required: true
+            regex: "^[a-z]+$"
       - 
         id: port 
         label: "Mysql port used on the host machine"

--- a/containers/nginx.yml
+++ b/containers/nginx.yml
@@ -16,6 +16,7 @@ config:
         value: nginx
         validators:
             required: true
+            regex: "^[a-z]+$"
       - 
         id: port 
         label: "Port used on the host machine"

--- a/containers/php.yml
+++ b/containers/php.yml
@@ -16,6 +16,7 @@ config:
         value: php
         validators:
           required: true
+          regex: "^[a-z]+$"
       - 
         id: application
         label: "Local path of the application"


### PR DESCRIPTION
I added a regex validation on container name in order to disallow special characters.
For example we won't be able anymore to name a container "alo ?"